### PR TITLE
Add PMC chairs as gatekeepers for variable approval processes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/docs/		@kjones207 @saori-tr @jonathanteper
+/docs/use-cases/		@kjones207 @saori-tr @jonathanteper

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/docs/		@kjones207 @saori-tr

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/docs/		@kjones207 @saori-tr
+/docs/		@kjones207 @saori-tr @jonathanteper


### PR DESCRIPTION
Since GH doesn't allow fine-grained control over approvals, our PMC leads must be the gatekeepers.
They can decide if it's a clerical change to fast-track, or a decision necessarily made by a larger group
and enforce by hand whatever decision making process the PMC settles on.